### PR TITLE
Added BLE Service deinitialize to avoid insufficient heap for HTTPS

### DIFF
--- a/BluetoothService.cpp
+++ b/BluetoothService.cpp
@@ -13,6 +13,10 @@ BluetoothService :: BluetoothService(){
   store = KeyStore :: getKeyStoreInstance();
   bleServer = NULL;
   bleService = NULL;
+  bleDeviceCharacteristic = NULL;
+  bleDeviceInfoCharacteristic = NULL;
+  bleNetworkCharacteristic = NULL;
+  bleConfigureCharacteristic = NULL;
 }
 
 void BluetoothService :: setClientConnected(bool status){
@@ -47,8 +51,8 @@ void BluetoothService :: initializeBLE(const char* dName){
 
   LOG("\nBluetoothService :: initializeBLE: BLE Server and BLE Service setup done");
 
-  BLECharacteristic *bleDeviceCharacteristic = bleService->createCharacteristic(DEVICE_CHARACTERISTIC_UUID,
-                                                                              BLECharacteristic::PROPERTY_READ);
+  bleDeviceCharacteristic = bleService->createCharacteristic(DEVICE_CHARACTERISTIC_UUID,
+                                                            BLECharacteristic::PROPERTY_READ);
 
   DynamicJsonBuffer jsonBuffer;
   JsonObject& doc = jsonBuffer.createObject();
@@ -64,17 +68,17 @@ void BluetoothService :: initializeBLE(const char* dName){
 
   LOG("\nBluetoothService :: initializeBLE: Setting Device Characteristic is done");
 
-  BLECharacteristic *bleDeviceInfoCharacteristic = bleService->createCharacteristic(DEVICE_INFO_CHARACTERISTIC_UUID,
-                                                                                BLECharacteristic::PROPERTY_READ);
+  bleDeviceInfoCharacteristic = bleService->createCharacteristic(DEVICE_INFO_CHARACTERISTIC_UUID,
+                                                                BLECharacteristic::PROPERTY_READ);
   bleDeviceInfoCharacteristic->setValue("{}");
   LOG("\nBluetoothService :: initializeBLE: Setting Device Info Characteristic is done");
 
-  BLECharacteristic *bleNetworkharacteristic = bleService->createCharacteristic(DEVICE_NETWORK_CHARACTERISTIC_UUID,
-                                                                                BLECharacteristic::PROPERTY_READ);
-  bleNetworkharacteristic->setValue("{}");
+  bleNetworkCharacteristic = bleService->createCharacteristic(DEVICE_NETWORK_CHARACTERISTIC_UUID,
+                                                                BLECharacteristic::PROPERTY_READ);
+  bleNetworkCharacteristic->setValue("{}");
   LOG("\nBluetoothService :: initializeBLE: Setting Network Characteristic is done");
 
-  BLECharacteristic *bleConfigureCharacteristic = bleService->createCharacteristic(CONFIGURE_CHARACTERISTIC_UUID,
+  bleConfigureCharacteristic = bleService->createCharacteristic(CONFIGURE_CHARACTERISTIC_UUID,
                                                                                 BLECharacteristic::PROPERTY_READ |
                                                                                 BLECharacteristic::PROPERTY_WRITE);
   bleConfigureCharacteristic->setValue("{}");
@@ -86,4 +90,37 @@ void BluetoothService :: initializeBLE(const char* dName){
   bleServer->getAdvertising()->addServiceUUID(bleService->getUUID());
   bleServer->getAdvertising()->start();
   LOG("\nBluetoothService :: initializeBLE: BLE Server Started Advertising, we should see in companion device");
+}
+
+void BluetoothService :: deInitializeBLE(){
+  LOG("\nBluetoothService :: deInitializeBLE: Stopping and Clearing BLE Service");
+
+  bleServer->getAdvertising()->stop();
+  LOG("\nBluetoothService :: deInitializeBLE: Advertising stopped...");
+
+  bleService->stop();
+  LOG("\nBluetoothService :: deInitializeBLE: BLE Service stopped...");
+
+  bleServer->removeService(bleService);
+  LOG("\nBluetoothService :: deInitializeBLE: BLE Service removed from BLE Server...");
+
+  if(bleConfigureCharacteristic != NULL) delete bleConfigureCharacteristic;
+  if(bleNetworkCharacteristic != NULL) delete bleNetworkCharacteristic;
+  if(bleDeviceInfoCharacteristic != NULL) delete bleDeviceInfoCharacteristic;
+  if(bleDeviceCharacteristic != NULL) delete bleDeviceCharacteristic;
+  LOG("\nBluetoothService :: deInitializeBLE: All characteristics memory freed...");
+
+  if(bleService != NULL) delete bleService;
+  LOG("\nBluetoothService :: deInitializeBLE: BLE Service instance freed...");
+
+  if(bleServer != NULL) delete bleServer;
+  LOG("\nBluetoothService :: deInitializeBLE:  BLE Server instance freed...");
+
+  BLEDevice::deinit(true);
+  LOG("\nBluetoothService :: deInitializeBLE: BLE Device deinitialized...");
+
+  if(deviceName != NULL) delete deviceName;
+  LOG("\nBluetoothService :: deInitializeBLE: Memory used for deviceName freed...");
+
+  LOG("\nBluetoothService :: deInitializeBLE: Done...");
 }

--- a/BluetoothService.h
+++ b/BluetoothService.h
@@ -22,6 +22,7 @@ class BluetoothService {
   public:
           BluetoothService();
           void initializeBLE(const char* deviceName=NULL);
+          void deInitializeBLE();
           bool isBLEClientConnected();
           static void setClientConnected(bool status);
   private:
@@ -30,16 +31,22 @@ class BluetoothService {
           KeyStore *store;
           BLEServer *bleServer;
           BLEService *bleService;
+          BLECharacteristic *bleDeviceCharacteristic;
+          BLECharacteristic *bleDeviceInfoCharacteristic;
+          BLECharacteristic *bleNetworkCharacteristic;
+          BLECharacteristic *bleConfigureCharacteristic;
           friend class BoTServerCallbacks;
 };
 
 class BoTServerCallbacks: public BLEServerCallbacks {
   friend class BluetoothService;
   void onConnect(BLEServer* pServer) {
+    LOG("\nBoTServerCallbacks :: onConnect: BLE Client Connected...");
     BluetoothService :: setClientConnected(true);
   };
 
   void onDisconnect(BLEServer* pServer) {
+    LOG("\nBoTServerCallbacks :: onDisconnect: BLE Client Disconnected...");
     BluetoothService :: setClientConnected(false);
   }
 };

--- a/BoTService.cpp
+++ b/BoTService.cpp
@@ -358,11 +358,13 @@ String BoTService :: post(const char* endPoint, const char* payload){
 
 void BoTService :: freeObjects(){
   if(httpClient != NULL) {
+     httpClient->end();
      delete httpClient;
      httpClient = NULL;
    }
 
   if(wifiClient != NULL) {
+    wifiClient->stop();
     delete wifiClient;
     wifiClient = NULL;
   }

--- a/PairingService.h
+++ b/PairingService.h
@@ -18,11 +18,11 @@ class PairingService {
   public:
     PairingService();
     void pairDevice();
+    String getPairingStatus();
   private:
     KeyStore *store;
     bool isPairable();
     bool isMultipair();
-    String getPairingStatus();
     bool pollPairingStatus();
 };
 #endif

--- a/Webserver.h
+++ b/Webserver.h
@@ -11,6 +11,7 @@
 #include "ControllerService.h"
 #include "ConfigurationService.h"
 #include "BluetoothService.h"
+#include "PairingService.h"
 #define STARTED 1
 #define NOT_STARTED 0
 

--- a/examples/SDKSample/sdkSample.ino
+++ b/examples/SDKSample/sdkSample.ino
@@ -95,6 +95,9 @@ void setup()
     //Variable to flag whether to load WiFi credentials from given configuration or not
     bool loadConfig = true;
 
+    //Override HTTPS
+    store->setHTTPS(true);
+
     //Instantiate Webserver by using WiFi credentials from configuration
     //server = new Webserver(loadConfig);
 


### PR DESCRIPTION
The commit contains the fix for HTTPS which used to fail due to insufficient heap on ESP-32 board as the BLE Service used to consume most of the heap. The fix contains the deinitialization of BLE Service as the BLE Client disconnects from the BLE Server.