### PR TITLE
Merge minor fix for isDeviceMultipair Method to develop branch

### DIFF
--- a/src/ConfigurationService.cpp
+++ b/src/ConfigurationService.cpp
@@ -19,8 +19,10 @@ void ConfigurationService :: initialize(){
   store->retrieveAllKeys();
   store->generateAndSaveQRCode();
   //Check device pair type and assign state accordingly
-  if(store->isDeviceMultipair())
+  if(store->isDeviceMultipair()){
     store->setDeviceState(DEVICE_MULTIPAIR);
+    debugD("\nConfigurationService :: initialize: Device is Multipair Enabled");
+  }
   else
     store->setDeviceState(DEVICE_NEW);
   debugD("\nConfigurationService :: initialize: Device State: %d",store->getDeviceState());

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -361,8 +361,7 @@ bool KeyStore :: isCACertLoaded(){
 }
 
 bool KeyStore :: isDeviceMultipair(){
-  if(multipair != NULL && multipair->equalsIgnoreCase("true") &&
-                                    getDeviceState() == DEVICE_MULTIPAIR)
+  if(multipair != NULL && multipair->equalsIgnoreCase("true"))
     return true;
   else
     return false;


### PR DESCRIPTION
The wrong and unnecessary condition getDeviceState == DEVICE_MULTIPAIR is removed from the method isDeviceMultipair as only the provided multipair flag is enough to check whether device is multipair enabled or not.